### PR TITLE
Make auto-value a compile only dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,9 @@ repositories {
 
 dependencies {
   compile libraries.guava,
-    libraries.jsr305,
-    libraries.autovalue
+    libraries.jsr305
+
+  compileOnly libraries.autovalue
 
   testCompile libraries.junit,
     libraries.mockito,
@@ -127,7 +128,8 @@ configurations {
 
 dependencies {
   codeGeneration libraries.autovalue, libraries.jsr305
-  compile libraries.autovalue, libraries.jsr305
+  compile libraries.jsr305
+  compileOnly libraries.autovalue
 }
 
 compileJava.classpath += configurations.codeGeneration


### PR DESCRIPTION
This avoids causing downstream users to download auto-value, which can trigger warnings like `warning: No processor claimed any of these annotations:` when using error-prone compiler. gRPC is encountering this issue when depending on any of the googleapi protos that transitively depend on api-common.