### PR TITLE
Add few improvements/fixes

### DIFF
--- a/src/main/java/com/google/api/core/AbstractApiFuture.java
+++ b/src/main/java/com/google/api/core/AbstractApiFuture.java
@@ -70,11 +70,11 @@ public abstract class AbstractApiFuture<V> implements ApiFuture<V> {
     return impl.isDone();
   }
 
-  public boolean set(V value) {
+  protected boolean set(V value) {
     return impl.set(value);
   }
 
-  public boolean setException(Throwable throwable) {
+  protected boolean setException(Throwable throwable) {
     return impl.setException(throwable);
   }
 
@@ -87,12 +87,12 @@ public abstract class AbstractApiFuture<V> implements ApiFuture<V> {
 
   private class InternalSettableFuture extends AbstractFuture<V> {
     @Override
-    public boolean set(@Nullable V value) {
+    protected boolean set(@Nullable V value) {
       return super.set(value);
     }
 
     @Override
-    public boolean setException(Throwable throwable) {
+    protected boolean setException(Throwable throwable) {
       return super.setException(throwable);
     }
 

--- a/src/main/java/com/google/api/core/ApiFutures.java
+++ b/src/main/java/com/google/api/core/ApiFutures.java
@@ -30,6 +30,8 @@
  */
 package com.google.api.core;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.AsyncFunction;
@@ -37,6 +39,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.List;
+import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 /** Static utility methods for the {@link ApiFuture} interface. */
@@ -45,6 +48,11 @@ public final class ApiFutures {
 
   public static <V> void addCallback(
       final ApiFuture<V> future, final ApiFutureCallback<? super V> callback) {
+    addCallback(future, callback, directExecutor());
+  }
+
+  public static <V> void addCallback(
+      final ApiFuture<V> future, final ApiFutureCallback<? super V> callback, Executor executor) {
     Futures.addCallback(
         listenableFutureForApiFuture(future),
         new FutureCallback<V>() {
@@ -57,7 +65,8 @@ public final class ApiFutures {
           public void onSuccess(V v) {
             callback.onSuccess(v);
           }
-        });
+        },
+        executor);
   }
 
   public static <V, X extends Throwable> ApiFuture<V> catching(
@@ -78,6 +87,10 @@ public final class ApiFutures {
 
   public static <V> ApiFuture<V> immediateFailedFuture(Throwable throwable) {
     return new ListenableFutureToApiFuture<V>(Futures.<V>immediateFailedFuture(throwable));
+  }
+
+  public static <V> ApiFuture<V> immediateCancelledFuture() {
+    return new ListenableFutureToApiFuture<V>(Futures.<V>immediateCancelledFuture());
   }
 
   public static <V, X> ApiFuture<X> transform(

--- a/src/main/java/com/google/api/core/SettableApiFuture.java
+++ b/src/main/java/com/google/api/core/SettableApiFuture.java
@@ -42,4 +42,14 @@ public final class SettableApiFuture<V> extends AbstractApiFuture<V> {
   public static <V> SettableApiFuture<V> create() {
     return new SettableApiFuture<>();
   }
+
+  @Override
+  protected boolean set(V value) {
+    return super.set(value);
+  }
+
+  @Override
+  protected boolean setException(Throwable throwable) {
+    return super.setException(throwable);
+  }
 }


### PR DESCRIPTION
1) Add ApiFutures.addCallback() method overloaded version which accepts executor
2) Add ApiFutures.immediateCancelledFuture() method
3) Remove "settability" from AbstractApiFuture and make that functionality available only in SettableApiFuture.