### PR TITLE
Upgrade to Guava 20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,10 @@ ext {
 
   // Shortcuts for libraries we are using
   libraries = [
-      guava: 'com.google.guava:guava:19.0',
+      guava: 'com.google.guava:guava:20.0',
       jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
       autovalue: 'com.google.auto.value:auto-value:1.1',
+      error_prone_annotations: 'com.google.errorprone:error_prone_annotations:2.1.3',
 
       // Testing
       junit: 'junit:junit:4.12',
@@ -63,7 +64,8 @@ dependencies {
   compile libraries.guava,
     libraries.jsr305
 
-  compileOnly libraries.autovalue
+  compileOnly libraries.autovalue,
+    libraries.error_prone_annotations
 
   testCompile libraries.junit,
     libraries.mockito,


### PR DESCRIPTION
@garrettjonesgoogle I can't explain why the error_prone_annotations dependency is needed here, but ti seems to be. 