### PR TITLE
Fix PathTemplate matcher to match path with protocol and hostname

### DIFF
--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -132,6 +132,9 @@ public class PathTemplate {
   // A regexp to match a custom verb at the end of a path.
   private static final Pattern CUSTOM_VERB_PATTERN = Pattern.compile(":([^/*}{=]+)$");
 
+  // A regex to match a hostname with or without protocol.
+  private static final Pattern HOSTNAME_PATTERN = Pattern.compile("^(\\w+:)?//");
+
   // A splitter on slash.
   private static final Splitter SLASH_SPLITTER = Splitter.on('/').trimResults();
 
@@ -533,10 +536,10 @@ public class PathTemplate {
       path = path.substring(0, matcher.start(0));
     }
 
-    // Do full match.
-    boolean withHostName = path.startsWith("//");
+    Matcher matcher = HOSTNAME_PATTERN.matcher(path);
+    boolean withHostName = matcher.find();
     if (withHostName) {
-      path = path.substring(2);
+      path = matcher.replaceFirst("");
     }
     List<String> input = SLASH_SPLITTER.splitToList(path);
     int inPos = 0;

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -555,10 +555,23 @@ public class PathTemplate {
       }
       values.put(HOSTNAME_VAR, hostName);
     }
+    if (withHostName && segments.get(0).kind() == SegmentKind.LITERAL) {
+      inPos = alignInputPositionToLiteralSegment(input, inPos, segments.get(0).value());
+    }
     if (!match(input, inPos, segments, 0, values)) {
       return null;
     }
     return ImmutableMap.copyOf(values);
+  }
+
+  private int alignInputPositionToLiteralSegment(List<String> input, int inPos,
+      String literalSegmentValue) {
+    for (; inPos < input.size(); inPos++) {
+      if (literalSegmentValue.equals(input.get(inPos))) {
+        return inPos;
+      }
+    }
+    return inPos;
   }
 
   // Tries to match the input based on the segments at given positions. Returns a boolean

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -551,7 +551,7 @@ public class PathTemplate {
       String hostName = input.get(inPos++);
       if (withHostName) {
         // Put the // back, so we can distinguish this case from forceHostName.
-        hostName = "//" + hostName;
+        hostName = matcher.group(0) + hostName;
       }
       values.put(HOSTNAME_VAR, hostName);
     }

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -125,8 +125,8 @@ public class PathTemplate {
 
   /**
    * A constant identifying the special variable used for endpoint bindings in the result of
-   * {@link #matchFromFullName(String)}. It may also contain protocol string, if its provided
-   * in the input.
+   * {@link #matchFromFullName(String)}. It may also contain protocol string, if its provided in the
+   * input.
    */
   public static final String HOSTNAME_VAR = "$hostname";
 

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -564,8 +564,9 @@ public class PathTemplate {
     return ImmutableMap.copyOf(values);
   }
 
-  private int alignInputPositionToLiteralSegment(List<String> input, int inPos,
-      String literalSegmentValue) {
+  // Aligns input to start of literal segment if input contains hostname.
+  private int alignInputPositionToLiteralSegment(
+      List<String> input, int inPos, String literalSegmentValue) {
     for (; inPos < input.size(); inPos++) {
       if (literalSegmentValue.equals(input.get(inPos))) {
         return inPos;

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -556,8 +556,8 @@ public class PathTemplate {
       }
       values.put(HOSTNAME_VAR, hostName);
     }
-    if (withHostName && segments.get(0).kind() == SegmentKind.LITERAL) {
-      inPos = alignInputPositionToLiteralSegment(input, inPos, segments.get(0).value());
+    if (withHostName) {
+      inPos = alignInputToAlignableSegment(input, inPos, segments.get(0));
     }
     if (!match(input, inPos, segments, 0, values)) {
       return null;
@@ -565,8 +565,20 @@ public class PathTemplate {
     return ImmutableMap.copyOf(values);
   }
 
-  // Aligns input to start of literal segment if input contains hostname.
-  private int alignInputPositionToLiteralSegment(
+  // Aligns input to start of literal value of literal or binding segment if input contains hostname.
+  private int alignInputToAlignableSegment(List<String> input, int inPos, Segment segment) {
+    switch (segment.kind()) {
+      case BINDING:
+        inPos = alignInputPositionToLiteral(input, inPos, segment.value() + "s");
+        return inPos + 1;
+      case LITERAL:
+        return alignInputPositionToLiteral(input, inPos, segment.value());
+    }
+    return inPos;
+  }
+
+  // Aligns input to start of literal value if input contains hostname.
+  private int alignInputPositionToLiteral(
       List<String> input, int inPos, String literalSegmentValue) {
     for (; inPos < input.size(); inPos++) {
       if (literalSegmentValue.equals(input.get(inPos))) {

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -125,7 +125,8 @@ public class PathTemplate {
 
   /**
    * A constant identifying the special variable used for endpoint bindings in the result of
-   * {@link #matchFromFullName(String)}.
+   * {@link #matchFromFullName(String)}. It may also contain protocol string, if its provided
+   * in the input.
    */
   public static final String HOSTNAME_VAR = "$hostname";
 

--- a/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
+++ b/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
@@ -84,6 +84,16 @@ public class PathTemplateTest {
   }
 
   @Test
+  public void matchWithHostNameAndProtocol() {
+    PathTemplate template = PathTemplate.create("buckets/*/objects/*");
+    Map<String, String> match = template.match("http://somewhere.io/buckets/b/objects/o");
+    Truth.assertThat(match).isNotNull();
+    Truth.assertThat(match.get(PathTemplate.HOSTNAME_VAR)).isEqualTo("http://somewhere.io");
+    Truth.assertThat(match.get("$0")).isEqualTo("b");
+    Truth.assertThat(match.get("$1")).isEqualTo("o");
+  }
+
+  @Test
   public void matchWithCustomMethod() {
     PathTemplate template = PathTemplate.create("buckets/*/objects/*:custom");
     Map<String, String> match = template.match("buckets/b/objects/o:custom");

--- a/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
+++ b/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
@@ -85,12 +85,13 @@ public class PathTemplateTest {
 
   @Test
   public void matchWithHostNameAndProtocol() {
-    PathTemplate template = PathTemplate.create("buckets/*/objects/*");
-    Map<String, String> match = template.match("http://somewhere.io/buckets/b/objects/o");
+    PathTemplate template = PathTemplate.create("projects/{project}/zones/{zone}");
+    Map<String, String> match = template
+        .match("https://www.googleapis.com/compute/v1/projects/project-123/zones/europe-west3-c");
     Truth.assertThat(match).isNotNull();
-    Truth.assertThat(match.get(PathTemplate.HOSTNAME_VAR)).isEqualTo("http://somewhere.io");
-    Truth.assertThat(match.get("$0")).isEqualTo("b");
-    Truth.assertThat(match.get("$1")).isEqualTo("o");
+    Truth.assertThat(match.get(PathTemplate.HOSTNAME_VAR)).isEqualTo("https://www.googleapis.com");
+    Truth.assertThat(match.get("project")).isEqualTo("project-123");
+    Truth.assertThat(match.get("zone")).isEqualTo("europe-west3-c");
   }
 
   @Test

--- a/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
+++ b/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
@@ -86,8 +86,9 @@ public class PathTemplateTest {
   @Test
   public void matchWithHostNameAndProtocol() {
     PathTemplate template = PathTemplate.create("projects/{project}/zones/{zone}");
-    Map<String, String> match = template
-        .match("https://www.googleapis.com/compute/v1/projects/project-123/zones/europe-west3-c");
+    Map<String, String> match =
+        template.match(
+            "https://www.googleapis.com/compute/v1/projects/project-123/zones/europe-west3-c");
     Truth.assertThat(match).isNotNull();
     Truth.assertThat(match.get(PathTemplate.HOSTNAME_VAR)).isEqualTo("https://www.googleapis.com");
     Truth.assertThat(match.get("project")).isEqualTo("project-123");

--- a/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
+++ b/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
@@ -96,6 +96,18 @@ public class PathTemplateTest {
   }
 
   @Test
+  public void matchWithHostNameAndProtocolWithTemplateStartWithBinding() {
+    PathTemplate template = PathTemplate.create("{project}/zones/{zone}");
+    Map<String, String> match =
+        template.match(
+            "https://www.googleapis.com/compute/v1/projects/project-123/zones/europe-west3-c");
+    Truth.assertThat(match).isNotNull();
+    Truth.assertThat(match.get(PathTemplate.HOSTNAME_VAR)).isEqualTo("https://www.googleapis.com");
+    Truth.assertThat(match.get("project")).isEqualTo("project-123");
+    Truth.assertThat(match.get("zone")).isEqualTo("europe-west3-c");
+  }
+
+  @Test
   public void matchWithCustomMethod() {
     PathTemplate template = PathTemplate.create("buckets/*/objects/*:custom");
     Map<String, String> match = template.match("buckets/b/objects/o:custom");


### PR DESCRIPTION
Fixes [#3604](https://github.com/googleapis/google-cloud-java/issues/3604) Fix matcher to match path with protocol and hostname