### PR TITLE
Automatic-Module-Name added to the manifest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ check.dependsOn jacocoTestReport
 // jar with automatic module name:
 jar {
   manifest {
-    attributes('Automatic-Module-Name': 'com.google.api.common')
+    attributes('Automatic-Module-Name': 'com.google.api.apicommon')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,13 @@ jacocoTestReport {
 
 check.dependsOn jacocoTestReport
 
+// jar with automatic module name:
+jar {
+  manifest {
+    attributes('Automatic-Module-Name': 'com.google.api.common')
+  }
+}
+
 // Source jar
 // ----------
 


### PR DESCRIPTION
As described in http://branchandbound.net/blog/java/2017/12/automatic-module-name/ , adding `Automatic-Module-Name` allows us to move to Java 11 without worrying that the jar file name will change.