### PR TITLE
Using the executor in ApiFutures.catching

### DIFF
--- a/src/main/java/com/google/api/core/ApiFutures.java
+++ b/src/main/java/com/google/api/core/ApiFutures.java
@@ -100,7 +100,7 @@ public final class ApiFutures {
             listenableFutureForApiFuture(input),
             exceptionType,
             new GaxFunctionToGuavaFunction<X, V>(callback),
-            directExecutor());
+            executor);
     return new ListenableFutureToApiFuture<V>(catchingFuture);
   }
 


### PR DESCRIPTION
An executor is passed in, but never used.

Fixes #72 