### PR TITLE
Modify PathTemplate so that double-star (PATH_WILDCARD) matches 0+ segments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,9 @@ targetCompatibility = 1.7
 // ------------
 
 ext {
-
   // Shortcuts for libraries we are using
   libraries = [
+      javax_annotations: 'javax.annotation:javax.annotation-api:1.3.1',
       guava: 'com.google.guava:guava:26.0-android',
       jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
       autovalue: 'com.google.auto.value:auto-value:1.1',
@@ -62,7 +62,8 @@ repositories {
 
 dependencies {
   compile libraries.guava,
-    libraries.jsr305
+    libraries.jsr305,
+    libraries.javax_annotations
 
   compileOnly libraries.autovalue,
     libraries.error_prone_annotations

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -612,7 +612,8 @@ public class PathTemplate {
           // This is the final segment, and this check should have already been performed by the
           // caller. The matching value is no longer present in the input.
           break;
-        default:
+        case LITERAL:
+        case WILDCARD:
           if (inPos >= input.size()) {
             // End of input
             return false;
@@ -627,36 +628,40 @@ public class PathTemplate {
           }
           if (currentVar != null) {
             // Create or extend current match
-            String current = values.get(currentVar);
-            if (current == null) {
-              values.put(currentVar, next);
-            } else {
-              values.put(currentVar, current + "/" + next);
+            values.put(currentVar, concatCaptures(values.get(currentVar), next));
+          }
+          break;
+        case PATH_WILDCARD:
+          // Compute the number of additional input the ** can consume. This
+          // is possible because we restrict patterns to have only one **.
+          int segsToMatch = 0;
+          for (int i = segPos; i < segments.size(); i++) {
+            switch (segments.get(i).kind()) {
+              case BINDING:
+              case END_BINDING:
+                // skip
+                continue;
+              default:
+                segsToMatch++;
             }
           }
-          if (seg.kind() == SegmentKind.PATH_WILDCARD) {
-            // Compute the number of additional input the ** can consume. This
-            // is possible because we restrict patterns to have only one **.
-            int segsToMatch = 0;
-            for (int i = segPos; i < segments.size(); i++) {
-              switch (segments.get(i).kind()) {
-                case BINDING:
-                case END_BINDING:
-                  // skip
-                  continue;
-                default:
-                  segsToMatch++;
-              }
-            }
-            int available = (input.size() - inPos) - segsToMatch;
-            while (available-- > 0) {
-              values.put(currentVar, values.get(currentVar) + "/" + decodeUrl(input.get(inPos++)));
-            }
+          int available = (input.size() - inPos) - segsToMatch;
+          // If this segment is empty, make sure it is still captured.
+          if (available == 0 && !values.containsKey(currentVar)) {
+            values.put(currentVar, "");
+          }
+          while (available-- > 0) {
+            values.put(currentVar, concatCaptures(values.get(currentVar), decodeUrl(input.get(inPos++))));
           }
       }
     }
     return inPos == input.size();
   }
+
+  private static String concatCaptures(@Nullable String cur, String next) {
+    return cur == null ? next : cur + "/" + next;
+  }
+
 
   // Template Instantiation
   // ======================

--- a/src/main/java/com/google/api/pathtemplate/PathTemplate.java
+++ b/src/main/java/com/google/api/pathtemplate/PathTemplate.java
@@ -651,7 +651,8 @@ public class PathTemplate {
             values.put(currentVar, "");
           }
           while (available-- > 0) {
-            values.put(currentVar, concatCaptures(values.get(currentVar), decodeUrl(input.get(inPos++))));
+            values.put(
+                currentVar, concatCaptures(values.get(currentVar), decodeUrl(input.get(inPos++))));
           }
       }
     }
@@ -661,7 +662,6 @@ public class PathTemplate {
   private static String concatCaptures(@Nullable String cur, String next) {
     return cur == null ? next : cur + "/" + next;
   }
-
 
   // Template Instantiation
   // ======================

--- a/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
+++ b/src/test/java/com/google/api/pathtemplate/PathTemplateTest.java
@@ -108,6 +108,37 @@ public class PathTemplateTest {
   }
 
   @Test
+  public void pathWildcards_matchZeroOrMoreSegments() {
+    PathTemplate start = PathTemplate.create("{glob=**}/b");
+    PathTemplate middle = PathTemplate.create("a/{glob=**}/b");
+    PathTemplate end = PathTemplate.create("a/{glob=**}");
+
+    Truth.assertThat(start.match("b").get("glob")).isEmpty();
+    Truth.assertThat(start.match("/b").get("glob")).isEmpty();
+    Truth.assertThat(start.match("a/b").get("glob")).isEqualTo("a");
+    Truth.assertThat(start.match("a/a/a/b").get("glob")).isEqualTo("a/a/a");
+
+    Truth.assertThat(middle.match("a/b").get("glob")).isEmpty();
+    Truth.assertThat(middle.match("a//b").get("glob")).isEmpty();
+    Truth.assertThat(middle.match("a/x/b").get("glob")).isEqualTo("x");
+    Truth.assertThat(middle.match("a/x/y/z/b").get("glob")).isEqualTo("x/y/z");
+
+    Truth.assertThat(end.match("a").get("glob")).isEmpty();
+    Truth.assertThat(end.match("a/").get("glob")).isEmpty();
+    Truth.assertThat(end.match("a/b").get("glob")).isEqualTo("b");
+    Truth.assertThat(end.match("a/b/b/b").get("glob")).isEqualTo("b/b/b");
+  }
+
+  @Test
+  public void pathWildcard_canMatchTheEmptyString() {
+    PathTemplate template = PathTemplate.create("{glob=**}");
+
+    Truth.assertThat(template.match("").get("glob")).isEmpty();
+    Truth.assertThat(template.match("a").get("glob")).isEqualTo("a");
+    Truth.assertThat(template.match("a/b").get("glob")).isEqualTo("a/b");
+  }
+
+  @Test
   public void matchWithCustomMethod() {
     PathTemplate template = PathTemplate.create("buckets/*/objects/*:custom");
     Map<String, String> match = template.match("buckets/b/objects/o:custom");


### PR DESCRIPTION
The existing behavior is to match 1+ segments. This is undesireable for some kinds of REST apis.

For instance, the Google Cloud Firestore emulator defines a REST api like
```
  /v1beta1/{parent=projects/*/databases/*/documents/**}/{collection_id}
```
which currently cannot match a path like
```
  /v1beta1/projects/rpb/databases/db/documents/foo
```
because the `**` cannot be empty.