### PR TITLE
ci: adding Kokoro build config of Linkage Monitor for api-common-java

### DIFF
--- a/.kokoro/linkage-monitor.sh
+++ b/.kokoro/linkage-monitor.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/linkage-monitor.sh
+++ b/.kokoro/linkage-monitor.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+# Display commands being run.
+set -x
+
+cd github/api-common-java/
+
+# Print out Java version
+java -version
+echo ${JOB_TYPE}
+
+mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V
+
+# Kokoro job cloud-opensource-java/ubuntu/linkage-monitor-gcs creates this JAR
+JAR=linkage-monitor-latest-all-deps.jar
+curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/${JAR}"
+
+# Fails if there's new linkage errors compared with baseline
+java -jar ${JAR} com.google.cloud:libraries-bom

--- a/.kokoro/presubmit/linkage-monitor.cfg
+++ b/.kokoro/presubmit/linkage-monitor.cfg
@@ -1,0 +1,12 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/api-common-java/.kokoro/linkage-monitor.sh"
+}


### PR DESCRIPTION
Part of https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1041