### PR TITLE
feat: add ApiFutures.catchingAsync

### DIFF
--- a/src/main/java/com/google/api/core/ApiFutures.java
+++ b/src/main/java/com/google/api/core/ApiFutures.java
@@ -104,6 +104,7 @@ public final class ApiFutures {
     return new ListenableFutureToApiFuture<V>(catchingFuture);
   }
 
+  @BetaApi
   public static <V, X extends Throwable> ApiFuture<V> catchingAsync(
       ApiFuture<V> input,
       Class<X> exceptionType,

--- a/src/main/java/com/google/api/core/ApiFutures.java
+++ b/src/main/java/com/google/api/core/ApiFutures.java
@@ -104,6 +104,26 @@ public final class ApiFutures {
     return new ListenableFutureToApiFuture<V>(catchingFuture);
   }
 
+  public static <V, X extends Throwable> ApiFuture<V> catchingAsync(
+      ApiFuture<V> input,
+      Class<X> exceptionType,
+      final ApiAsyncFunction<? super X, V> callback,
+      Executor executor) {
+    ListenableFuture<V> catchingFuture =
+        Futures.catchingAsync(
+            listenableFutureForApiFuture(input),
+            exceptionType,
+            new AsyncFunction<X, V>() {
+              @Override
+              public ListenableFuture<V> apply(X exception) throws Exception {
+                ApiFuture<V> result = callback.apply(exception);
+                return listenableFutureForApiFuture(result);
+              }
+            },
+            executor);
+    return new ListenableFutureToApiFuture<>(catchingFuture);
+  }
+
   public static <V> ApiFuture<V> immediateFuture(V value) {
     return new ListenableFutureToApiFuture<>(Futures.<V>immediateFuture(value));
   }

--- a/src/test/java/com/google/api/core/ApiFuturesTest.java
+++ b/src/test/java/com/google/api/core/ApiFuturesTest.java
@@ -84,6 +84,24 @@ public class ApiFuturesTest {
   }
 
   @Test
+  public void testCatchAsync() throws Exception {
+    SettableApiFuture<Integer> future = SettableApiFuture.<Integer>create();
+    ApiFuture<Integer> fallback =
+        ApiFutures.catchingAsync(
+            future,
+            Exception.class,
+            new ApiAsyncFunction<Exception, Integer>() {
+              @Override
+              public ApiFuture<Integer> apply(Exception ex) {
+                return ApiFutures.immediateFuture(42);
+              }
+            },
+            directExecutor());
+    future.setException(new Exception());
+    assertThat(fallback.get()).isEqualTo(42);
+  }
+
+  @Test
   public void testTransform() throws Exception {
     SettableApiFuture<Integer> inputFuture = SettableApiFuture.<Integer>create();
     ApiFuture<String> transformedFuture =


### PR DESCRIPTION
I would like to use this in Firestore. I tried to match the existing signature that allows the callback to return '? extends V' but this does not seem to be possible (see transformAsync).