### PR TITLE
feat: add ApiFutures.successfulAsList

### DIFF
--- a/src/main/java/com/google/api/core/ApiFutures.java
+++ b/src/main/java/com/google/api/core/ApiFutures.java
@@ -172,6 +172,21 @@ public final class ApiFutures {
                   }
                 })));
   }
+
+  @BetaApi
+  public static <V> ApiFuture<List<V>> successfulAsList(
+      Iterable<? extends ApiFuture<? extends V>> futures) {
+    return new ListenableFutureToApiFuture<>(
+        Futures.successfulAsList(
+            Iterables.transform(
+                futures,
+                new Function<ApiFuture<? extends V>, ListenableFuture<? extends V>>() {
+                  public ListenableFuture<? extends V> apply(ApiFuture<? extends V> apiFuture) {
+                    return listenableFutureForApiFuture(apiFuture);
+                  }
+                })));
+  }
+
   /*
    * @deprecated Use {@linkplain #transformAsync(ApiFuture, ApiFunction, Executor) the
    * overload that requires an executor}. For identical behavior, pass {@link

--- a/src/test/java/com/google/api/core/ApiFuturesTest.java
+++ b/src/test/java/com/google/api/core/ApiFuturesTest.java
@@ -155,6 +155,17 @@ public class ApiFuturesTest {
   }
 
   @Test
+  public void successfulAllAsList() throws Exception {
+    SettableApiFuture<Integer> inputFuture1 = SettableApiFuture.<Integer>create();
+    SettableApiFuture<Integer> inputFuture2 = SettableApiFuture.<Integer>create();
+    ApiFuture<List<Integer>> listFuture =
+        ApiFutures.successfulAsList(ImmutableList.of(inputFuture1, inputFuture2));
+    inputFuture1.set(1);
+    inputFuture2.setException(new Exception());
+    assertThat(listFuture.get()).containsExactly(1, null).inOrder();
+  }
+
+  @Test
   public void testTransformAsync() throws Exception {
     ApiFuture<Integer> inputFuture = ApiFutures.immediateFuture(0);
     ApiFuture<Integer> outputFuture =


### PR DESCRIPTION
I would like to use this in the java-firestore repo. This PR exposes `ApiFutures.successfulAsList` ([link](https://docs.oracle.com/javase/7/docs/api/java/lang/Iterable.html?is-external=true)). 

Here is a PR that uses it ([link](https://github.com/googleapis/java-firestore/pull/286/files#diff-b72bbfd868696254f62dee9fda1592fcR491)). `successfulAsList` allows me to wait for all Futures to complete (`ApiFutures.allAsList` completes early if an exception is thrown) before I run my listener. The alternative implementation without this method would be to manually add listeners to all the ApiFutures in order to handle exceptions.