### PR TITLE
chore: remove deprecated `maven` plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Gradle Test
       run: ./gradlew test
     - name: Gradle Build
-      run: ./gradlew build install
+      run: ./gradlew build publishToMavenLocal
   format:
     runs-on: ubuntu-latest
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ apply plugin: 'idea'
 apply plugin: 'jacoco'
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
-apply plugin: 'maven'
 apply plugin: 'com.github.sherter.google-java-format'
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 


### PR DESCRIPTION
The `maven` Gradle plugin is deprecated. The project already applies the `maven-publish` plugin that supersedes it, so the `maven` plugin is actually redundant.

Ref: #304