### PR TITLE
chore: Cleanup old CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,25 +5,6 @@ on:
   pull_request:
 name: ci
 jobs:
-  units:
-    runs-on: ubuntu-latest
-    env:
-      # Customize the JVM maximum heap limit
-      JVM_OPTS: -Xmx3200m
-      TERM: dumb
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - run: java -version
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
   clirr:
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +23,7 @@ jobs:
         env:
           JOB_TYPE: clirr
   units-8:
-    name: units (8) - Maven
+    name: units (8)
     runs-on: ubuntu-latest
     steps:
       - name: Get current week within the year
@@ -68,7 +49,7 @@ jobs:
         env:
           JOB_TYPE: test
           JOB_NAME: units-8
-  units-maven:
+  units:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This was part of the previous PR https://github.com/googleapis/api-common-java/pull/376#issuecomment-1330814171