### PR TITLE
chore: Use Java11 for release

### DIFF
--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -9,7 +9,7 @@ build_file: "api-common-java/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
 }
 
 before_action {


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Build with JDK11 and target JDK8
END_COMMIT_OVERRIDE

Error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project api-common: Fatal error compiling: invalid flag: --release -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```