### PR TITLE
chore: Replace release flag with source/target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,8 @@
                             <version>${auto-value.version}</version>
                         </path>
                     </annotationProcessorPaths>
-                    <release>8</release>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <compilerArgs>
                         <arg>-Xlint:unchecked</arg>
                         <arg>-Xlint:deprecation</arg>


### PR DESCRIPTION
Building with java8 instead of java9+